### PR TITLE
Allow device URL to set from enviroment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This sample will need be publicly accessible to the internet in order for Bandwi
 
 **Unless you are running on `localhost`, you will need to use HTTPS**. Most modern browsers require a secure context when accessing cameras and microphones.
 
+Note that this sample currently works best in Chrome or Firefox!
+
 
 ### Create a Bandwidth Voice API application
 Follow the steps in [How to Create a Voice API Application](https://support.bandwidth.com/hc/en-us/articles/360035060934-How-to-Create-a-Voice-API-Application-V2-) to create your Voice API appliation.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This sample will need be publicly accessible to the internet in order for Bandwi
 
 **Unless you are running on `localhost`, you will need to use HTTPS**. Most modern browsers require a secure context when accessing cameras and microphones.
 
-Note that this sample currently works best in Chrome or Firefox!
+Note that this sample currently works best in Chrome.
 
 
 ### Create a Bandwidth Voice API application

--- a/frontend/src/Conference.tsx
+++ b/frontend/src/Conference.tsx
@@ -102,10 +102,14 @@ const Conference: React.FC = props => {
       if (conferenceId) {
         const responseBody = await response.json();
         const participantId = responseBody.id;
+        let options: any = {};
+        if (responseBody.websocketUrl) {
+          options.websocketUrl = responseBody.websocketUrl;
+        }
         await bandwidthRtc.connect({
           conferenceId: conferenceId,
           participantId: participantId
-        });
+        }, options);
         const publishResponse = await bandwidthRtc.publish();
         setLocalStream(publishResponse);
       }

--- a/server.ts
+++ b/server.ts
@@ -22,7 +22,9 @@ const voiceAppId = <string>process.env.VOICE_APP_ID;
 const voiceCallbackUrl = <string>process.env.VOICE_CALLBACK_URL;
 
 const port = process.env.PORT || 3000;
-const websocketUrl = <string>process.env.WEBRTC_SERVER_URL;
+const websocketServerUrl = <string>process.env.WEBRTC_SERVER_URL;
+const websocketDeviceUrl = <string>process.env.WEBRTC_DEVICE_URL;
+
 const app = express();
 
 interface Conference {
@@ -40,8 +42,8 @@ interface Participant {
 
 const bandwidthRtc = new BandwidthRtc();
 let options: any = {};
-if (websocketUrl) {
-  options.websocketUrl = websocketUrl;
+if (websocketServerUrl) {
+  options.websocketUrl = websocketServerUrl;
 }
 bandwidthRtc
   .connect({
@@ -151,7 +153,7 @@ app.post("/conferences/:conferenceId/participants", async (req, res) => {
       if (phoneNumber) {
         callPhoneNumber(phoneNumber, conferenceId, participantId);
       }
-      res.status(200).send({ id: participantId });
+      res.status(200).send({ id: participantId, websocketUrl: websocketDeviceUrl });
     } else {
       res.status(404).send();
     }


### PR DESCRIPTION
Let the device websocket URL be set from an environment variable so different WebRTC environments can be targeted.