### PR TITLE
Wait until removeParticipant returns before modifying local state.

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -322,10 +322,10 @@ bandwidthRtc.onParticipantLeft(async (event: ParticipantLeftEvent) => {
   const participantId = event.participantId;
   const conference = conferences.get(conferenceId);
   if (conference) {
-    // Remove the participant from our local state
-    conference.participants.delete(participantId);
     // Remove the participant from the conference
     await bandwidthRtc.removeParticipant(conferenceId, participantId);
+    // Remove the participant from our local state
+    conference.participants.delete(participantId);
     // If everyone has left the conference, let's shut it down
     if (conference.participants.size === 0) {
       await bandwidthRtc.endConference(conferenceId);


### PR DESCRIPTION
This avoids accidentally calling `endConference` multiple times when participant leave around the same time.