### PR TITLE
EDGE-886 Remove participant from session when cleaning up participant

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Add your Bandwidth account settings to `.env`:
 
 * WEBRTC_HTTP_SERVER_URL (Customer API URL, which defaults to `https://api.webrtc.bandwidth.com/v1`. Optionally override if you want to use your personal stack instead, i.e. `https://sife6x5c6l.execute-api.us-east-1.amazonaws.com/v1`)
 * WEBRTC_DEVICE_URL (Device Websocket API URL, which defaults to `wss://device.webrtc.bandwidth.com`. Optionally override if you want to use your personal stack instead, i.e. `wss://t7b04iwatb.execute-api.us-east-1.amazonaws.com`)
+* CALLBACK\_URL (the publicly accessible URL for your app, i.e. ngrok URL, with no trailing slash)
 
 Add your Voice Application settings to `.env`:
 * VOICE\_NUMBER (Bandwith phone number associated with the Voice Application in [E.164 format](https://www.bandwidth.com/glossary/e164/))
-* VOICE\_CALLBACK\_URL (the publicly accessible URL for your app, i.e. ngrok URL, with no trailing slash)
 
 ## Install dependencies and build
 

--- a/server.ts
+++ b/server.ts
@@ -196,6 +196,23 @@ const addParticipantToSession = async (participantId: string, sessionId: string)
   sessionIdsToParticipantIds.get(sessionId)?.add(participantId);
 }
 
+const removeParticipantFromSession = async (participantId: string, sessionId: string) => {
+  console.log(`Removing participant ${participantId} from session ${sessionId}`);
+  try {
+    await axios.delete(
+        `${httpServerUrl}/accounts/${accountId}/sessions/${sessionId}/participants/${participantId}`,
+        {
+          auth: {
+            username: username,
+            password: password
+          }
+        }
+    )
+  } catch (err) {
+    console.log(`Error removing participant ${participantId} from session ${sessionId}`, err.response.data);
+  }
+}
+
 const deleteParticipant = async (participantId: string) => {
   console.log(`Deleting participant ${participantId}`);
   try {
@@ -223,6 +240,10 @@ const cleanupParticipant = async (participantId: string) => {
   participantIdsToCleanupTimeouts.delete(participantId);
   const sessionId = participantIdsToSessionIds.get(participantId);
   participantIdsToSessionIds.delete(participantId);
+
+  if (sessionId) {
+    await removeParticipantFromSession(participantId, sessionId);
+  }
 
   await deleteParticipant(participantId);
   


### PR DESCRIPTION
Tested locally pointing to staging. Got no errors:

```
Received WebRTC callback (179ms delay) {
  event: 'onLeave',
  timestamp: 1622065930109,
  participantId: '532838e1-9ff2-4944-aacf-40c653105b43',
  deviceId: '6990c865-e3d3-4841-a6ed-67fb9854e8e8',
  tag: 'causable-sakimonkey'
}
Cleaning up participant 532838e1-9ff2-4944-aacf-40c653105b43
Removing participant 532838e1-9ff2-4944-aacf-40c653105b43 from session 4886cc5b-fcf9-4def-8af5-92e12944626
```